### PR TITLE
Fix Add Random Items button to work with scroll selector

### DIFF
--- a/src/pybackstock/app.py
+++ b/src/pybackstock/app.py
@@ -207,7 +207,8 @@ def handle_random_action() -> tuple[list[str], list[Any], int]:
     count_added = 0
 
     try:
-        count = int(request.form.get("random-count", 5))
+        # Support both old and new field names for backwards compatibility
+        count = int(request.form.get("random-item-count", request.form.get("random-count", 5)))
         # Limit to reasonable range
         count = max(1, min(count, 50))
 
@@ -279,7 +280,10 @@ def index() -> str:
         elif FormAction.ADD_CSV in request.form:
             load_search, load_add_item, load_add_csv, load_add_random = False, False, True, False
         elif FormAction.ADD_RANDOM in request.form:
-            load_search, load_add_item, load_add_csv, load_add_random = False, False, False, True
+            # Directly add random items when button is clicked
+            load_search, load_add_item, load_add_csv, load_add_random = False, True, False, False
+            errors, items, random_count = handle_random_action()
+            random_added = random_count > 0
         # Handle form submissions
         elif FormAction.SEND_SEARCH in request.form:
             load_search, load_add_item, load_add_csv, load_add_random = True, False, False, False

--- a/templates/index.html
+++ b/templates/index.html
@@ -224,6 +224,129 @@
         }
       }
 
+      /* Random Item Count Selector Styles */
+      .random-count-selector {
+        margin-bottom: 10px;
+        width: 100%;
+      }
+
+      .random-count-selector label {
+        font-weight: bold;
+        margin-bottom: 8px;
+        display: block;
+        font-size: 14px;
+      }
+
+      .range-selector-wrapper {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        width: 100%;
+      }
+
+      .range-selector {
+        flex: 1;
+        -webkit-appearance: none;
+        appearance: none;
+        height: 8px;
+        background: linear-gradient(to right, #CE2029 0%, #CE2029 var(--range-progress, 10%), #dee2e6 var(--range-progress, 10%), #dee2e6 100%);
+        border-radius: 4px;
+        outline: none;
+        cursor: pointer;
+      }
+
+      .range-selector::-webkit-slider-thumb {
+        -webkit-appearance: none;
+        appearance: none;
+        width: 24px;
+        height: 24px;
+        background: #CE2029;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 3px solid white;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+        transition: transform 0.2s, box-shadow 0.2s;
+      }
+
+      .range-selector::-webkit-slider-thumb:hover {
+        transform: scale(1.1);
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      }
+
+      .range-selector::-moz-range-thumb {
+        width: 24px;
+        height: 24px;
+        background: #CE2029;
+        border-radius: 50%;
+        cursor: pointer;
+        border: 3px solid white;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+        transition: transform 0.2s, box-shadow 0.2s;
+      }
+
+      .range-selector::-moz-range-thumb:hover {
+        transform: scale(1.1);
+        box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
+      }
+
+      .range-selector:focus {
+        outline: 2px solid #CE2029;
+        outline-offset: 4px;
+      }
+
+      .count-display {
+        min-width: 50px;
+        text-align: center;
+        font-weight: bold;
+        font-size: 18px;
+        color: #CE2029;
+        background: #f8f9fa;
+        padding: 6px 12px;
+        border-radius: 4px;
+        border: 2px solid #CE2029;
+      }
+
+      .range-labels {
+        display: flex;
+        justify-content: space-between;
+        font-size: 12px;
+        color: #666;
+        margin-top: 4px;
+        padding: 0 2px;
+      }
+
+      /* Mobile adjustments for range selector */
+      @media (max-width: 768px) {
+        .range-selector-wrapper {
+          flex-direction: column;
+          gap: 8px;
+        }
+
+        .range-selector {
+          width: 100%;
+          height: 12px;
+        }
+
+        .range-selector::-webkit-slider-thumb {
+          width: 32px;
+          height: 32px;
+        }
+
+        .range-selector::-moz-range-thumb {
+          width: 32px;
+          height: 32px;
+        }
+
+        .count-display {
+          font-size: 20px;
+          padding: 8px 16px;
+        }
+
+        .random-count-selector label {
+          font-size: 16px;
+        }
+      }
+
       /* Visualization Selector Styles */
       .viz-selector-container {
         margin-bottom: 10px;
@@ -488,6 +611,26 @@
           </form>
           <form role="form" name="add-random-form" method="POST" action="/">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <!-- Random Item Count Selector -->
+            <div class="random-count-selector">
+              <label for="random-item-count">Items:</label>
+              <div class="range-selector-wrapper">
+                <input type="range"
+                       name="random-item-count"
+                       id="random-item-count"
+                       class="range-selector"
+                       min="1"
+                       max="50"
+                       value="5"
+                       aria-label="Number of random items to add (1-50)"
+                       aria-describedby="random-count-display">
+                <span id="random-count-display" class="count-display">5</span>
+              </div>
+              <div class="range-labels">
+                <span>1</span>
+                <span>50</span>
+              </div>
+            </div>
             <button name="add-random" id="random" type="submit" class="btn btn-menu">Add Random Items</button>
           </form>
           <form role="form" name="generate-report-form" method="GET" action="/report" id="report-form">
@@ -799,6 +942,35 @@
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 
     <script>
+      // Random item count selector functionality
+      (function() {
+        const rangeInput = document.getElementById('random-item-count');
+        const countDisplay = document.getElementById('random-count-display');
+
+        if (!rangeInput || !countDisplay) return;
+
+        // Update display and progress bar
+        function updateRangeDisplay() {
+          const value = rangeInput.value;
+          countDisplay.textContent = value;
+
+          // Calculate progress percentage for gradient background
+          const min = parseInt(rangeInput.min);
+          const max = parseInt(rangeInput.max);
+          const progress = ((value - min) / (max - min)) * 100;
+          rangeInput.style.setProperty('--range-progress', progress + '%');
+        }
+
+        // Initialize display
+        updateRangeDisplay();
+
+        // Update on input (real-time as slider moves)
+        rangeInput.addEventListener('input', updateRangeDisplay);
+
+        // Also update on change for compatibility
+        rangeInput.addEventListener('change', updateRangeDisplay);
+      })();
+
       // Visualization selector functionality
       (function() {
         const dropdownToggle = document.getElementById('viz-dropdown-toggle');

--- a/tests/test_add_random_button.py
+++ b/tests/test_add_random_button.py
@@ -1,0 +1,234 @@
+"""Tests for the Add Random Items button with direct add functionality.
+
+TDD/BDD tests for ensuring the Add Random Items button:
+1. Has a scroll selector (1-50) above it for selecting item count
+2. Directly adds items when clicked (single action, no intermediate form)
+3. Works correctly on both web and mobile (responsive design)
+"""
+
+import os
+
+# Set test environment BEFORE importing app modules
+os.environ["APP_SETTINGS"] = "src.pybackstock.config.TestingConfig"
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+import pytest
+from flask.testing import FlaskClient
+
+
+class TestAddRandomButtonDisplay:
+    """Tests for the Add Random Items button and selector display."""
+
+    @pytest.mark.integration
+    def test_main_page_has_random_count_selector(self, client: FlaskClient) -> None:
+        """Test that the main page displays a count selector above the Add Random Items button."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Check for the range input selector
+        assert 'id="random-item-count"' in data or 'name="random-item-count"' in data
+
+    @pytest.mark.integration
+    def test_random_count_selector_has_range_1_to_50(self, client: FlaskClient) -> None:
+        """Test that the count selector allows values from 1 to 50."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Check for min and max attributes on the selector
+        assert 'min="1"' in data
+        assert 'max="50"' in data
+
+    @pytest.mark.integration
+    def test_random_count_selector_default_value(self, client: FlaskClient) -> None:
+        """Test that the count selector has a reasonable default value."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Check for default value (should be 5 or similar)
+        assert 'value="5"' in data or 'value="10"' in data
+
+    @pytest.mark.integration
+    def test_random_count_selector_is_visible_on_main_page(self, client: FlaskClient) -> None:
+        """Test that the selector is on the main page, not behind a form."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # The selector should be within the add-random-form, visible immediately
+        assert 'name="add-random-form"' in data
+        # Should have a label for the selector
+        assert "Items:" in data or "Number" in data
+
+    @pytest.mark.integration
+    def test_random_count_display_shows_current_value(self, client: FlaskClient) -> None:
+        """Test that there's a display showing the current selected count."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have a value display element
+        assert 'id="random-count-display"' in data or 'class="count-display"' in data
+
+
+class TestAddRandomButtonFunctionality:
+    """Tests for the Add Random Items button direct add functionality."""
+
+    @pytest.mark.integration
+    def test_add_random_button_directly_adds_items(self, client: FlaskClient) -> None:
+        """Test that clicking Add Random Items directly adds items without intermediate form."""
+        # Click the button with a count value - should add items immediately
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "3"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should show success message, NOT the intermediate form
+        assert "Successfully generated 3 random item" in data
+        # Should NOT show the old intermediate form elements
+        assert "Generate Random Test Items" not in data
+
+    @pytest.mark.integration
+    def test_add_random_button_uses_selector_value(self, client: FlaskClient) -> None:
+        """Test that the button uses the value from the selector."""
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "7"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert "Successfully generated 7 random item" in data
+
+    @pytest.mark.integration
+    def test_add_random_button_defaults_to_5_if_no_count(self, client: FlaskClient) -> None:
+        """Test that the button defaults to 5 items if no count is provided."""
+        response = client.post(
+            "/",
+            data={"add-random": ""},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should add 5 items by default
+        assert "Successfully generated 5 random item" in data
+
+    @pytest.mark.integration
+    def test_add_random_limits_count_to_50(self, client: FlaskClient) -> None:
+        """Test that count is limited to 50 even if higher value submitted."""
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "100"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should be limited to 50
+        assert "Successfully generated 50 random item" in data
+
+    @pytest.mark.integration
+    def test_add_random_minimum_count_is_1(self, client: FlaskClient) -> None:
+        """Test that count is at least 1 even if 0 or negative submitted."""
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "0"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should be at least 1
+        assert "Successfully generated 1 random item" in data
+
+    @pytest.mark.integration
+    def test_add_random_items_persisted_to_database(self, client: FlaskClient) -> None:
+        """Test that added random items are actually persisted to the database."""
+        # Add 3 random items
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "3"},
+        )
+        assert response.status_code == 200
+
+        # Search for items by department (should find something)
+        # Random items will have departments from the corpus
+        response = client.post(
+            "/",
+            data={"send-search": "", "column": "id", "item": "1"},
+        )
+        assert response.status_code == 200
+        # If items were created, search should succeed without errors
+
+
+class TestAddRandomButtonMobileResponsive:
+    """Tests for mobile responsiveness of the Add Random Items selector."""
+
+    @pytest.mark.integration
+    def test_page_has_viewport_meta_for_mobile(self, client: FlaskClient) -> None:
+        """Test that the page has viewport meta tag for mobile responsiveness."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert 'name="viewport"' in data
+        assert "width=device-width" in data
+
+    @pytest.mark.integration
+    def test_random_selector_has_touch_friendly_size(self, client: FlaskClient) -> None:
+        """Test that CSS includes touch-friendly sizing for the selector."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Check for CSS that ensures touch-friendly sizing
+        # Range inputs should have adequate height for touch
+        assert "range-selector" in data or "random-item-count" in data
+
+    @pytest.mark.integration
+    def test_random_selector_mobile_media_query(self, client: FlaskClient) -> None:
+        """Test that there are mobile-specific styles for the selector."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have mobile media queries
+        assert "@media (max-width: 768px)" in data
+
+    @pytest.mark.integration
+    def test_add_random_button_has_touch_target_size(self, client: FlaskClient) -> None:
+        """Test that the Add Random Items button has minimum touch target size."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Check for button styling that ensures touch-friendly size
+        # The btn-menu class should have adequate sizing
+        assert "btn-menu" in data
+        assert "min-height" in data
+
+
+class TestAddRandomButtonAccessibility:
+    """Tests for accessibility of the Add Random Items selector."""
+
+    @pytest.mark.integration
+    def test_random_selector_has_label(self, client: FlaskClient) -> None:
+        """Test that the selector has an associated label for accessibility."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have a label for the range input
+        assert 'for="random-item-count"' in data or "Items:" in data
+
+    @pytest.mark.integration
+    def test_random_selector_has_aria_attributes(self, client: FlaskClient) -> None:
+        """Test that the selector has appropriate ARIA attributes."""
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have aria-label or aria-describedby
+        assert "aria-" in data

--- a/tests/test_random_items.py
+++ b/tests/test_random_items.py
@@ -351,11 +351,11 @@ class TestRandomItemsIntegration:
     """Integration tests for random items with the web app."""
 
     def test_add_random_items_route(self, client: FlaskClient) -> None:
-        """Test the add random items button shows the form."""
-        response = client.post("/", data={"add-random": ""})
+        """Test the add random items button directly adds items."""
+        response = client.post("/", data={"add-random": "", "random-item-count": "5"})
         assert response.status_code == 200
-        assert b"Generate Random Test Items" in response.data
-        assert b"Number of Items" in response.data
+        # Button now directly adds items instead of showing a form
+        assert b"Successfully generated 5 random item" in response.data
 
     def test_generate_random_items_route(self, client: FlaskClient) -> None:
         """Test generating random items via the form."""


### PR DESCRIPTION
- Add scroll/range selector (1-50) above Add Random Items button
- Change button to directly add items without intermediate form
- Add mobile-responsive CSS for the range selector
- Include JavaScript for real-time display updates
- Add TDD/BDD tests for selector display, functionality,
  mobile responsiveness, and accessibility
- Update existing tests to match new behavior