### PR TITLE
Fix Add Random Items button and add editable number input

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -97,12 +97,20 @@ paths:
                   type: string
                 add-csv:
                   type: string
+                add-random:
+                  type: string
                 send-search:
                   type: string
                 send-add:
                   type: string
+                send-random:
+                  type: string
                 csv-submit:
                   type: string
+                random-item-count:
+                  type: integer
+                  minimum: 1
+                  maximum: 50
           multipart/form-data:
             schema:
               type: object

--- a/src/pybackstock/api/handlers.py
+++ b/src/pybackstock/api/handlers.py
@@ -26,6 +26,7 @@ from src.pybackstock.app import (
     calculate_top_value_data,
     handle_add_action,
     handle_csv_action,
+    handle_random_action,
     handle_search_action,
 )
 
@@ -157,26 +158,38 @@ def index_post() -> str:
     load_search = False
     load_add_item = True
     load_add_csv = False
+    load_add_random = False
     item_searched = False
     item_added = False
+    random_added = False
+    random_count = 0
 
     # Handle form view switching
     if FormAction.SEARCH_ITEM in request.form:
-        load_search, load_add_item, load_add_csv = True, False, False
+        load_search, load_add_item, load_add_csv, load_add_random = True, False, False, False
     elif FormAction.ADD_ITEM in request.form:
-        load_search, load_add_item, load_add_csv = False, True, False
+        load_search, load_add_item, load_add_csv, load_add_random = False, True, False, False
     elif FormAction.ADD_CSV in request.form:
-        load_search, load_add_item, load_add_csv = False, False, True
+        load_search, load_add_item, load_add_csv, load_add_random = False, False, True, False
+    elif FormAction.ADD_RANDOM in request.form:
+        # Directly add random items when button is clicked
+        load_search, load_add_item, load_add_csv, load_add_random = False, True, False, False
+        errors, items, random_count = handle_random_action()
+        random_added = random_count > 0
     # Handle form submissions
     elif FormAction.SEND_SEARCH in request.form:
-        load_search, load_add_item, load_add_csv = True, False, False
+        load_search, load_add_item, load_add_csv, load_add_random = True, False, False, False
         errors, items, item_searched, item_added = handle_search_action()
     elif FormAction.SEND_ADD in request.form:
-        load_search, load_add_item, load_add_csv = False, True, False
+        load_search, load_add_item, load_add_csv, load_add_random = False, True, False, False
         errors, items, item_searched, item_added = handle_add_action()
     elif FormAction.CSV_SUBMIT in request.form:
-        load_search, load_add_item, load_add_csv = False, False, True
+        load_search, load_add_item, load_add_csv, load_add_random = False, False, True, False
         errors, items = handle_csv_action()
+    elif FormAction.SEND_RANDOM in request.form:
+        load_search, load_add_item, load_add_csv, load_add_random = False, False, False, True
+        errors, items, random_count = handle_random_action()
+        random_added = random_count > 0
 
     return render_template(
         "index.html",
@@ -186,8 +199,11 @@ def index_post() -> str:
         loading_search=load_search,
         loading_add_item=load_add_item,
         loading_add_csv=load_add_csv,
+        loading_add_random=load_add_random,
         item_searched=item_searched,
         item_added=item_added,
+        random_added=random_added,
+        random_count=random_count,
     )
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -296,6 +296,7 @@
 
       .count-display {
         min-width: 50px;
+        width: 60px;
         text-align: center;
         font-weight: bold;
         font-size: 18px;
@@ -304,6 +305,39 @@
         padding: 6px 12px;
         border-radius: 4px;
         border: 2px solid #CE2029;
+      }
+
+      .count-input {
+        cursor: text;
+        outline: none;
+        transition: border-color 0.2s, box-shadow 0.2s;
+      }
+
+      .count-input:focus {
+        border-color: #a01a21;
+        box-shadow: 0 0 0 3px rgba(206, 32, 41, 0.2);
+      }
+
+      .count-input.error {
+        border-color: #dc3545;
+        background-color: #fff5f5;
+        animation: shake 0.3s ease-in-out;
+      }
+
+      @keyframes shake {
+        0%, 100% { transform: translateX(0); }
+        25% { transform: translateX(-4px); }
+        75% { transform: translateX(4px); }
+      }
+
+      .count-error {
+        color: #dc3545;
+        font-size: 12px;
+        margin-top: 6px;
+        padding: 4px 8px;
+        background-color: #fff5f5;
+        border-radius: 4px;
+        border-left: 3px solid #dc3545;
       }
 
       .range-labels {
@@ -624,12 +658,18 @@
                        value="5"
                        aria-label="Number of random items to add (1-50)"
                        aria-describedby="random-count-display">
-                <span id="random-count-display" class="count-display">5</span>
+                <input type="text"
+                       id="random-count-display"
+                       class="count-display count-input"
+                       value="5"
+                       maxlength="2"
+                       aria-label="Enter number of items (1-50)">
               </div>
               <div class="range-labels">
                 <span>1</span>
                 <span>50</span>
               </div>
+              <div id="random-count-error" class="count-error" style="display: none;"></div>
             </div>
             <button name="add-random" id="random" type="submit" class="btn btn-menu">Add Random Items</button>
           </form>
@@ -945,30 +985,119 @@
       // Random item count selector functionality
       (function() {
         const rangeInput = document.getElementById('random-item-count');
-        const countDisplay = document.getElementById('random-count-display');
+        const countInput = document.getElementById('random-count-display');
+        const errorDiv = document.getElementById('random-count-error');
 
-        if (!rangeInput || !countDisplay) return;
+        if (!rangeInput || !countInput) return;
 
-        // Update display and progress bar
-        function updateRangeDisplay() {
-          const value = rangeInput.value;
-          countDisplay.textContent = value;
+        const MIN_VALUE = 1;
+        const MAX_VALUE = 50;
 
-          // Calculate progress percentage for gradient background
+        // Update progress bar gradient
+        function updateProgressBar(value) {
           const min = parseInt(rangeInput.min);
           const max = parseInt(rangeInput.max);
           const progress = ((value - min) / (max - min)) * 100;
           rangeInput.style.setProperty('--range-progress', progress + '%');
         }
 
+        // Show error message
+        function showError(message) {
+          if (errorDiv) {
+            errorDiv.textContent = message;
+            errorDiv.style.display = 'block';
+          }
+          countInput.classList.add('error');
+        }
+
+        // Clear error message
+        function clearError() {
+          if (errorDiv) {
+            errorDiv.style.display = 'none';
+            errorDiv.textContent = '';
+          }
+          countInput.classList.remove('error');
+        }
+
+        // Validate and parse input value
+        function validateInput(inputValue) {
+          // Check if input is empty
+          if (inputValue.trim() === '') {
+            return { valid: false, error: 'Please enter a number between 1-50' };
+          }
+
+          // Check if input contains only digits
+          if (!/^\d+$/.test(inputValue.trim())) {
+            return { valid: false, error: 'Invalid input. Please enter a number between 1-50' };
+          }
+
+          const numValue = parseInt(inputValue, 10);
+
+          // Check if value is in range
+          if (numValue < MIN_VALUE || numValue > MAX_VALUE) {
+            return { valid: false, error: 'Invalid input. Please enter a number between 1-50' };
+          }
+
+          return { valid: true, value: numValue };
+        }
+
+        // Update input from slider
+        function updateFromSlider() {
+          const value = rangeInput.value;
+          countInput.value = value;
+          updateProgressBar(value);
+          clearError();
+        }
+
+        // Update slider from input
+        function updateFromInput() {
+          const result = validateInput(countInput.value);
+
+          if (result.valid) {
+            rangeInput.value = result.value;
+            updateProgressBar(result.value);
+            clearError();
+          } else {
+            showError(result.error);
+          }
+        }
+
         // Initialize display
-        updateRangeDisplay();
+        updateFromSlider();
 
-        // Update on input (real-time as slider moves)
-        rangeInput.addEventListener('input', updateRangeDisplay);
+        // Update on slider input (real-time as slider moves)
+        rangeInput.addEventListener('input', updateFromSlider);
 
-        // Also update on change for compatibility
-        rangeInput.addEventListener('change', updateRangeDisplay);
+        // Also update on slider change for compatibility
+        rangeInput.addEventListener('change', updateFromSlider);
+
+        // Update on count input change
+        countInput.addEventListener('input', function() {
+          // Allow typing, validate on blur or enter
+          clearError();
+        });
+
+        countInput.addEventListener('blur', updateFromInput);
+
+        countInput.addEventListener('keydown', function(e) {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            updateFromInput();
+            countInput.blur();
+          }
+        });
+
+        // Prevent non-numeric input (allow backspace, delete, arrows, tab)
+        countInput.addEventListener('keypress', function(e) {
+          const allowedKeys = ['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight', 'Tab'];
+          if (allowedKeys.includes(e.key)) return;
+
+          // Only allow digits
+          if (!/^\d$/.test(e.key)) {
+            e.preventDefault();
+            showError('Invalid input. Please enter a number between 1-50');
+          }
+        });
       })();
 
       // Visualization selector functionality

--- a/tests/test_add_random_button.py
+++ b/tests/test_add_random_button.py
@@ -7,12 +7,14 @@ TDD/BDD tests for ensuring the Add Random Items button:
 """
 
 import os
+from pathlib import Path
 
 # Set test environment BEFORE importing app modules
 os.environ["APP_SETTINGS"] = "src.pybackstock.config.TestingConfig"
 os.environ["DATABASE_URL"] = "sqlite:///:memory:"
 
 import pytest
+import yaml
 from flask.testing import FlaskClient
 
 
@@ -620,9 +622,7 @@ class TestOpenAPISpecRandomItems:
         When I check the POST / endpoint schema
         Then it should include add-random property
         """
-        import yaml
-
-        with open("openapi.yaml") as f:
+        with Path("openapi.yaml").open() as f:
             spec = yaml.safe_load(f)
 
         post_spec = spec["paths"]["/"]["post"]
@@ -639,9 +639,7 @@ class TestOpenAPISpecRandomItems:
         When I check the POST / endpoint schema
         Then it should include random-item-count property with constraints
         """
-        import yaml
-
-        with open("openapi.yaml") as f:
+        with Path("openapi.yaml").open() as f:
             spec = yaml.safe_load(f)
 
         post_spec = spec["paths"]["/"]["post"]
@@ -662,9 +660,7 @@ class TestOpenAPISpecRandomItems:
         When I check the POST / endpoint schema
         Then it should include send-random property for form submission
         """
-        import yaml
-
-        with open("openapi.yaml") as f:
+        with Path("openapi.yaml").open() as f:
             spec = yaml.safe_load(f)
 
         post_spec = spec["paths"]["/"]["post"]

--- a/tests/test_add_random_button.py
+++ b/tests/test_add_random_button.py
@@ -232,3 +232,443 @@ class TestAddRandomButtonAccessibility:
         data = response.data.decode("utf-8")
         # Should have aria-label or aria-describedby
         assert "aria-" in data
+
+
+class TestEditableNumberInput:
+    """BDD tests for the editable number input field that syncs with the slider.
+
+    Feature: Editable Random Items Count Input
+        As a user
+        I want to click on the number display and type a value directly
+        So that I can quickly set the exact number of random items to add
+    """
+
+    @pytest.mark.integration
+    def test_count_display_is_input_field(self, client: FlaskClient) -> None:
+        """Scenario: Count display is an editable input field.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then the count display should be an input element (not just a span)
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # The count display should be an input element with type="text"
+        assert 'id="random-count-display"' in data
+        assert 'class="count-display count-input"' in data
+        # Should be an input, not a span
+        assert '<input type="text"' in data
+
+    @pytest.mark.integration
+    def test_count_input_has_default_value(self, client: FlaskClient) -> None:
+        """Scenario: Count input shows default value.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then the count input should show the default value of 5
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have value="5" for the input
+        assert 'id="random-count-display"' in data
+        # The input element should have a value attribute
+        assert 'value="5"' in data
+
+    @pytest.mark.integration
+    def test_count_input_has_maxlength_attribute(self, client: FlaskClient) -> None:
+        """Scenario: Count input restricts length.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then the count input should have maxlength of 2 (for values 1-50)
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert 'maxlength="2"' in data
+
+    @pytest.mark.integration
+    def test_count_input_has_accessibility_label(self, client: FlaskClient) -> None:
+        """Scenario: Count input is accessible.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then the count input should have an aria-label for screen readers
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have an aria-label explaining the input
+        assert 'aria-label="Enter number of items (1-50)"' in data
+
+
+class TestInputValidationUIElements:
+    """BDD tests for validation error display elements.
+
+    Feature: Input Validation Feedback
+        As a user
+        I want to see clear error messages when I enter invalid values
+        So that I know how to correct my input
+    """
+
+    @pytest.mark.integration
+    def test_error_container_exists(self, client: FlaskClient) -> None:
+        """Scenario: Error message container is present.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be a hidden error container ready to show messages
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Error container should exist with id for JavaScript to target
+        assert 'id="random-count-error"' in data
+        # Should have the error styling class
+        assert 'class="count-error"' in data
+        # Should be hidden by default
+        assert 'style="display: none;"' in data
+
+    @pytest.mark.integration
+    def test_error_styling_exists(self, client: FlaskClient) -> None:
+        """Scenario: Error styling is defined.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be CSS styles for error states
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # CSS for error state on input
+        assert ".count-input.error" in data
+        # CSS for error message container
+        assert ".count-error" in data
+
+    @pytest.mark.integration
+    def test_input_has_focus_styling(self, client: FlaskClient) -> None:
+        """Scenario: Input has focus styling.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be CSS styles for input focus state
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # CSS for focus state
+        assert ".count-input:focus" in data
+
+    @pytest.mark.integration
+    def test_shake_animation_defined(self, client: FlaskClient) -> None:
+        """Scenario: Shake animation is defined for errors.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be a shake animation keyframe for error feedback
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Shake animation for invalid input feedback
+        assert "@keyframes shake" in data
+
+
+class TestSliderInputSyncJavaScript:
+    """BDD tests for JavaScript slider-input synchronization.
+
+    Feature: Bidirectional Slider-Input Sync
+        As a user
+        I want the slider and input to stay synchronized
+        So that I can use either control method
+    """
+
+    @pytest.mark.integration
+    def test_javascript_sync_code_exists(self, client: FlaskClient) -> None:
+        """Scenario: JavaScript for sync is present.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be JavaScript code for syncing slider and input
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have the IIFE for random item count functionality
+        assert "// Random item count selector functionality" in data
+        # Should have references to both elements
+        assert "getElementById('random-item-count')" in data
+        assert "getElementById('random-count-display')" in data
+
+    @pytest.mark.integration
+    def test_javascript_validation_code_exists(self, client: FlaskClient) -> None:
+        """Scenario: JavaScript for validation is present.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be JavaScript code for input validation
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have validation function
+        assert "validateInput" in data
+        # Should check for valid range
+        assert "MIN_VALUE" in data
+        assert "MAX_VALUE" in data
+
+    @pytest.mark.integration
+    def test_javascript_error_handling_code_exists(self, client: FlaskClient) -> None:
+        """Scenario: JavaScript for error handling is present.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be JavaScript functions for showing/hiding errors
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should have error handling functions
+        assert "showError" in data
+        assert "clearError" in data
+        # Should have error message text
+        assert "Please enter a number between 1-50" in data
+
+    @pytest.mark.integration
+    def test_javascript_event_listeners_exist(self, client: FlaskClient) -> None:
+        """Scenario: JavaScript event listeners are attached.
+
+        Given I am on the main inventory page
+        When the page loads
+        Then there should be event listeners for user interactions
+        """
+        response = client.get("/")
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should listen to slider events
+        assert "addEventListener('input'" in data
+        assert "addEventListener('change'" in data
+        # Should listen to input blur and keydown
+        assert "addEventListener('blur'" in data
+        assert "addEventListener('keydown'" in data
+        # Should prevent non-numeric input
+        assert "addEventListener('keypress'" in data
+
+
+class TestAPIHandlerRandomItemsSupport:
+    """BDD tests for API handler support of random items action.
+
+    Feature: API Handler Random Items Support
+        As a user
+        I want the Add Random Items button to work through the API handler
+        So that items are actually added to the database
+    """
+
+    @pytest.mark.integration
+    def test_api_handler_processes_add_random_action(self, client: FlaskClient) -> None:
+        """Scenario: API handler processes add-random action.
+
+        Given I submit a form with add-random action
+        When the request is processed
+        Then random items should be added to the database
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "3"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Should show success message
+        assert "Successfully generated 3 random item" in data
+
+    @pytest.mark.integration
+    def test_api_handler_returns_random_added_flag(self, client: FlaskClient) -> None:
+        """Scenario: API handler sets random_added flag.
+
+        Given I submit a form with add-random action
+        When items are successfully added
+        Then the template should receive random_added=True
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "2"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        # Success message indicates random_added was True
+        assert "Successfully generated" in data
+        assert "random" in data.lower()
+
+    @pytest.mark.integration
+    def test_api_handler_returns_random_count(self, client: FlaskClient) -> None:
+        """Scenario: API handler returns correct item count.
+
+        Given I submit a form requesting 5 random items
+        When the items are added
+        Then the response should indicate 5 items were added
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "5"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert "Successfully generated 5 random item" in data
+
+    @pytest.mark.integration
+    def test_api_handler_validates_count_upper_bound(self, client: FlaskClient) -> None:
+        """Scenario: API handler limits count to 50.
+
+        Given I submit a form requesting 100 random items
+        When the request is processed
+        Then only 50 items should be added (upper limit)
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "100"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert "Successfully generated 50 random item" in data
+
+    @pytest.mark.integration
+    def test_api_handler_validates_count_lower_bound(self, client: FlaskClient) -> None:
+        """Scenario: API handler ensures minimum count of 1.
+
+        Given I submit a form requesting 0 random items
+        When the request is processed
+        Then at least 1 item should be added (lower limit)
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "0"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert "Successfully generated 1 random item" in data
+
+    @pytest.mark.integration
+    def test_api_handler_handles_negative_count(self, client: FlaskClient) -> None:
+        """Scenario: API handler handles negative count.
+
+        Given I submit a form with negative count
+        When the request is processed
+        Then at least 1 item should be added
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "-5"},
+        )
+        assert response.status_code == 200
+
+        data = response.data.decode("utf-8")
+        assert "Successfully generated 1 random item" in data
+
+    @pytest.mark.integration
+    def test_api_handler_handles_non_numeric_count(self, client: FlaskClient) -> None:
+        """Scenario: API handler handles non-numeric count gracefully.
+
+        Given I submit a form with non-numeric count
+        When the request is processed
+        Then it should use default value of 5
+        """
+        response = client.post(
+            "/",
+            data={"add-random": "", "random-item-count": "abc"},
+        )
+        assert response.status_code == 200
+
+        # Should either use default or handle gracefully
+        data = response.data.decode("utf-8")
+        # The page should load without crashing
+        assert "<!DOCTYPE html>" in data or "<!doctype html>" in data.lower()
+
+
+class TestOpenAPISpecRandomItems:
+    """BDD tests for OpenAPI specification random items support.
+
+    Feature: OpenAPI Specification Support
+        As a developer
+        I want the OpenAPI spec to include random items properties
+        So that the API is properly documented
+    """
+
+    @pytest.mark.unit
+    def test_openapi_includes_add_random_property(self) -> None:
+        """Scenario: OpenAPI spec includes add-random property.
+
+        Given the OpenAPI specification file
+        When I check the POST / endpoint schema
+        Then it should include add-random property
+        """
+        import yaml
+
+        with open("openapi.yaml") as f:
+            spec = yaml.safe_load(f)
+
+        post_spec = spec["paths"]["/"]["post"]
+        form_schema = post_spec["requestBody"]["content"]["application/x-www-form-urlencoded"]["schema"]
+        properties = form_schema["properties"]
+
+        assert "add-random" in properties
+
+    @pytest.mark.unit
+    def test_openapi_includes_random_item_count_property(self) -> None:
+        """Scenario: OpenAPI spec includes random-item-count property.
+
+        Given the OpenAPI specification file
+        When I check the POST / endpoint schema
+        Then it should include random-item-count property with constraints
+        """
+        import yaml
+
+        with open("openapi.yaml") as f:
+            spec = yaml.safe_load(f)
+
+        post_spec = spec["paths"]["/"]["post"]
+        form_schema = post_spec["requestBody"]["content"]["application/x-www-form-urlencoded"]["schema"]
+        properties = form_schema["properties"]
+
+        assert "random-item-count" in properties
+        count_prop = properties["random-item-count"]
+        assert count_prop["type"] == "integer"
+        assert count_prop["minimum"] == 1
+        assert count_prop["maximum"] == 50
+
+    @pytest.mark.unit
+    def test_openapi_includes_send_random_property(self) -> None:
+        """Scenario: OpenAPI spec includes send-random property.
+
+        Given the OpenAPI specification file
+        When I check the POST / endpoint schema
+        Then it should include send-random property for form submission
+        """
+        import yaml
+
+        with open("openapi.yaml") as f:
+            spec = yaml.safe_load(f)
+
+        post_spec = spec["paths"]["/"]["post"]
+        form_schema = post_spec["requestBody"]["content"]["application/x-www-form-urlencoded"]["schema"]
+        properties = form_schema["properties"]
+
+        assert "send-random" in properties


### PR DESCRIPTION
- Fix API handler (handlers.py) to support ADD_RANDOM action that was
  missing from the Connexion route handler
- Add random-item-count and add-random properties to OpenAPI spec
- Convert count display span to editable input field with validation
- Add bidirectional sync between slider and input (1-50 range)
- Show error message for invalid inputs (non-numeric or out of range)
- Add CSS styles for input focus state and error state with shake animation